### PR TITLE
specified the package name for function HMMsegment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.3.2
 Date: 2019-07-22
 Author: Gavin Ha, Justin Rhoades, Samuel Freeman
 Maintainer: Gavin Ha <gha@fredhutch.org>, Justin Rhoades <rhoades@broadinstitute.org>, Sam Freeman <sfreeman@broadinstitute.org>
-Depends: R (>= 3.6.0)
+Depends: R (>= 3.5.0)
 biocViews:
 Imports: HMMcopy (== 1.26.0), plyr (>= 1.8.4), GenomicRanges (>= 1.36.0), GenomeInfoDb (>= 1.20.0)
 Description: A tool for estimating the fraction of tumor in ultra-low-pass whole genome sequencing (ULP-WGS) of cell-free DNA.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Author: Gavin Ha, Justin Rhoades, Samuel Freeman
 Maintainer: Gavin Ha <gha@fredhutch.org>, Justin Rhoades <rhoades@broadinstitute.org>, Sam Freeman <sfreeman@broadinstitute.org>
 Depends: R (>= 3.6.0)
 biocViews:
-Imports: HMMcopy (>= 1.14.0), plyr (>= 1.8.4), GenomicRanges (>= 1.36.0), GenomeInfoDb (>= 1.20.0)
+Imports: HMMcopy (== 1.26.0), plyr (>= 1.8.4), GenomicRanges (>= 1.36.0), GenomeInfoDb (>= 1.20.0)
 Description: A tool for estimating the fraction of tumor in ultra-low-pass whole genome sequencing (ULP-WGS) of cell-free DNA.
 License: GPL-3
 URL: https://github.com/broadinstitute/ichorCNA

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Author: Gavin Ha, Justin Rhoades, Samuel Freeman
 Maintainer: Gavin Ha <gha@fredhutch.org>, Justin Rhoades <rhoades@broadinstitute.org>, Sam Freeman <sfreeman@broadinstitute.org>
 Depends: R (>= 3.5.0)
 biocViews:
-Imports: HMMcopy (== 1.26.0), plyr (>= 1.8.4), GenomicRanges (>= 1.36.0), GenomeInfoDb (>= 1.20.0)
+Imports: HMMcopy (== 1.24.0), plyr (>= 1.8.4), GenomicRanges (>= 1.36.0), GenomeInfoDb (>= 1.20.0)
 Description: A tool for estimating the fraction of tumor in ultra-low-pass whole genome sequencing (ULP-WGS) of cell-free DNA.
 License: GPL-3
 URL: https://github.com/broadinstitute/ichorCNA

--- a/scripts/runIchorCNA.R
+++ b/scripts/runIchorCNA.R
@@ -298,7 +298,7 @@ for (n in normal){
 		#############################################
 		################ RUN HMM ####################
 		#############################################
-    hmmResults.cor <- HMMsegment(tumour_copy, valid, dataType = "copy", 
+    hmmResults.cor <- ichorCNA::HMMsegment(tumour_copy, valid, dataType = "copy", 
                                  param = param, chrTrain = chrTrain, maxiter = 50,
                                  estimateNormal = estimateNormal, estimatePloidy = estimatePloidy,
                                  estimateSubclone = estimateScPrevalence, verbose = TRUE)


### PR DESCRIPTION
R pkg _**HMMcopy**_ and _**ichorCNA**_  both have a function called _HMMsegment_, I think it's safer to specify the package name? Especially for those used R package called "_**conflicted**_", the analysis will be stopped by "**_conflicted_**" issuing an error message.